### PR TITLE
[fix] 내일 날씨 음성 안내에서 현재 기온 제거

### DIFF
--- a/src/components/WeatherDisplay.tsx
+++ b/src/components/WeatherDisplay.tsx
@@ -64,8 +64,10 @@ const WeatherDisplay: React.FC<WeatherDisplayProps> = ({ weatherInfo, isToday })
         <Text style={styles.conditionText}>{getConditionText()}</Text>
         
         <View style={styles.tempContainer}>
-          <Text style={styles.currentTemp}>{Math.round(weatherInfo.temp)}°</Text>
-          
+          {isToday && (
+           <Text style={styles.currentTemp}>{Math.round(weatherInfo.temp)}°</Text>
+           )}
+
           <View style={styles.minMaxContainer}>
             <View style={styles.tempRow}>
               <Ionicons name="arrow-up" size={24} color={colors.text} />

--- a/src/constants/strings.ts
+++ b/src/constants/strings.ts
@@ -19,10 +19,10 @@ export const STRINGS = {
     TAP_TO_REPEAT_LABEL: '날씨 정보를 다시 들으려면 화면을 탭하세요',
     
     // Weather info phrases
-    CURRENT_TEMP: '현재 온도는 %s도입니다.',
-    HIGH_TEMP: '최고 온도는 %s도입니다.',
-    LOW_TEMP: '최저 온도는 %s도입니다.',
-    FEELS_LIKE: '체감 온도는 %s도입니다.',
+    CURRENT_TEMP: '현재 기온은 %s도입니다.',
+    HIGH_TEMP: '최고 기온은 %s도입니다.',
+    LOW_TEMP: '최저 기온은 %s도입니다.',
+    FEELS_LIKE: '체감 기온은 %s도입니다.',
     WEATHER_CONDITION: '날씨는 %s입니다.',
     RAIN_PROBABILITY: '강수 확률은 %s퍼센트입니다.',
     RAIN_AMOUNT: '예상 강수량은 %s밀리미터입니다.',
@@ -64,7 +64,7 @@ export const STRINGS = {
     HELP_TODAY: '오늘 날씨 버튼을 누르면 현재 날씨 정보를 음성으로 알려드립니다.',
     HELP_TOMORROW: '내일 날씨 버튼을 누르면 내일 날씨 예보를 음성으로 알려드립니다.',
     HELP_REPEAT: '날씨 정보를 다시 들으려면 화면을 탭하세요.',
-    HELP_CONTACT: '추가 도움이 필요하시면 가족에게 문의하세요.',
+    HELP_CONTACT: '도움이 필요하면 문의주세요.',
   };
   
   // Storage keys

--- a/src/screens/WeatherScreen.tsx
+++ b/src/screens/WeatherScreen.tsx
@@ -52,7 +52,7 @@ const WeatherScreen: React.FC = () => {
     if (!weatherInfo) return '';
     
     const dayText = isToday ? STRINGS.TODAY_WEATHER : STRINGS.TOMORROW_WEATHER;
-    const tempText = STRINGS.CURRENT_TEMP.replace('%s', Math.round(weatherInfo.temp).toString());
+    const tempText = isToday ? STRINGS.CURRENT_TEMP.replace('%s', Math.round(weatherInfo.temp).toString()) : '';
     const highText = STRINGS.HIGH_TEMP.replace('%s', Math.round(weatherInfo.tempMax).toString());
     const lowText = STRINGS.LOW_TEMP.replace('%s', Math.round(weatherInfo.tempMin).toString());
     const feelsLikeText = STRINGS.FEELS_LIKE.replace('%s', Math.round(weatherInfo.feelsLike).toString());
@@ -113,7 +113,7 @@ const WeatherScreen: React.FC = () => {
       rainAmountText = `예상 강수량은 ${mm}밀리미터로, ${desc}`;
     }
   
-    return `${dayText}. ${tempText} ${highText} ${lowText} ${feelsLikeText} ${weatherConditionText} ${rainText} ${rainAmountText}`.trim();
+    return `${dayText}. ${isToday ? tempText : ''} ${highText} ${lowText} ${feelsLikeText} ${weatherConditionText} ${rainText} ${rainAmountText}`.trim();
   };
 
   // Speak weather information when data is loaded


### PR DESCRIPTION
**설명:**
“내일 날씨” 안내 시 불필요하게 포함되어 있던 현재 기온 안내를 제거합니다.
사용자가 내일 날씨를 듣는 상황에서는 현재 기온 정보가 오해를 줄 수 있기 때문에 제거하는 것이 적절합니다.

**변경 사항:**
- WeatherScreen.tsx 내 getWeatherSpeechText() 함수에서
tempText를 isToday일 때만 포함되도록 조건부 분기
```
const tempText = isToday ? STRINGS.CURRENT_TEMP.replace(...) : '';
```
- return 텍스트 구성 시에도 isToday 여부로 현재 기온 포함 여부 제어

**이슈 연결:**
Closes #6
